### PR TITLE
build for Linux

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-go build && \
+GOOS=linux go build && \
 zip ephemeral.zip ephemeral && \
 rm ephemeral && \
 aws lambda update-function-code --function-name ephemeral --zip-file fileb://ephemeral.zip && \


### PR DESCRIPTION
`exec format error` is thrown if you build this go binary on OSX